### PR TITLE
correct spelling of "labels" in Code Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ For Image to World generation, you can use the following code:
 # First, generate a Panorama image with  An Image.
 python3 demo_panogen.py --prompt "" --image_path examples/case2/input.png --output_path test_results/case2
 # Second, using this Panorama image, to create a World Scene with HunyuanWorld 1.0
-# You can indicate the foreground objects lables you want to layer out by using params labels_fg1 & labels_fg2
+# You can indicate the foreground objects labels you want to layer out by using params labels_fg1 & labels_fg2
 # such as --labels_fg1 sculptures flowers --labels_fg2 tree mountains
 CUDA_VISIBLE_DEVICES=0 python3 demo_scenegen.py --image_path test_results/case2/panorama.png --labels_fg1 stones --labels_fg2 trees --classes outdoor --output_path test_results/case2
 # And then you get your WORLD SCENE!!
@@ -185,7 +185,7 @@ For Text to World generation, you can use the following code:
 # First, generate a Panorama image with A Prompt.
 python3 demo_panogen.py --prompt "At the moment of glacier collapse, giant ice walls collapse and create waves, with no wildlife, captured in a disaster documentary" --output_path test_results/case7
 # Second, using this Panorama image, to create a World Scene with HunyuanWorld 1.0
-# You can indicate the foreground objects lables you want to layer out by using params labels_fg1 & labels_fg2
+# You can indicate the foreground objects labels you want to layer out by using params labels_fg1 & labels_fg2
 # such as --labels_fg1 sculptures flowers --labels_fg2 tree mountains
 CUDA_VISIBLE_DEVICES=0 python3 demo_scenegen.py --image_path test_results/case7/panorama.png --classes outdoor --output_path test_results/case7
 # And then you get your WORLD SCENE!!


### PR DESCRIPTION
- Fixed typo "lables" → "labels" in parameter descriptions
- Affects both Image to World and Text to World generation examples