### PR TITLE
[Bugfix] 修复 Perspective 投影类的纵横比计算错误及边缘伪影 Fix geometric distortion and edge artifacts in Perspective projection

### DIFF
--- a/hy3dworld/utils/perspective_utils.py
+++ b/hy3dworld/utils/perspective_utils.py
@@ -37,14 +37,14 @@ class Perspective:
         self.THETA = THETA
         self.PHI = PHI
         if self._width > self._height:
-            self.wFOV = FOV
-            self.hFOV = (float(self._height) / self._width) * FOV
+            self.w_len = np.tan(np.radians(FOV / 2.0))
+            self.h_len = self.w_len * float(self._height) / self._width
         else:
-            self.wFOV = (float(self._width) / self._height) * FOV
-            self.hFOV = FOV
+            self.h_len = np.tan(np.radians(FOV / 2.0))
+            self.w_len = self.h_len * float(self._width) / self._height
 
-        self.w_len = np.tan(np.radians(self.wFOV / 2.0))
-        self.h_len = np.tan(np.radians(self.hFOV / 2.0))
+        self.wFOV = np.degrees(2 * np.arctan(self.w_len))
+        self.hFOV = np.degrees(2 * np.arctan(self.h_len))
 
     def GetEquirec(self, height, width, img=None):
         #
@@ -99,7 +99,7 @@ class Perspective:
             0)
         # Remap the image using the longitude and latitude maps
         persp = cv2.remap(self._img, lon_map.astype(np.float32), lat_map.astype(
-            np.float32), cv2.INTER_CUBIC, borderMode=cv2.BORDER_WRAP)  # BORDER_CONSTANT) #))
+            np.float32), cv2.INTER_CUBIC, borderMode=cv2.BORDER_CONSTANT, borderValue=(0, 0, 0))
         # Apply the mask to the equirectangular image
         mask = mask * inverse_mask
         mask = np.repeat(mask[:, :, np.newaxis], 3, axis=2)


### PR DESCRIPTION
**Problem:**
1. **Geometric Distortion:** The original code calculated `hFOV` (and consequently `h_len`) using linear scaling based on the aspect ratio: `self.hFOV = (float(self._height) / self._width) * FOV`. In perspective projection, the relationship between FOV and image dimension is non-linear (tangent function). This linear approximation caused vertical squashing/stretching when the image aspect ratio was not 1:1.
2. **Edge Artifacts:** Using `cv2.BORDER_WRAP` in `cv2.remap` caused pixel bleeding from the opposite side of the image at the edges, which is incorrect for perspective images (unlike equirectangular ones).

**Evidence:**
For a 1024x512 image (2:1 ratio) with 90° horizontal FOV:
- **Old implementation:** Calculated `h_len` ≈ 0.414 (corresponding to ~45° vertical FOV).
- **New implementation:** Calculates `h_len` = 0.5 (corresponding to ~53.1° vertical FOV).
This fix ensures square pixels are maintained regardless of the input resolution.

**Fix:**
1. Updated `__init__` to calculate `w_len` and `h_len` using `np.tan`, strictly following the perspective projection geometry.
2. Added back-calculation of `wFOV` and `hFOV` attributes to maintain backward compatibility.
3. Changed `cv2.remap` border mode to `cv2.BORDER_CONSTANT` (black padding) to eliminate edge artifacts.

**问题描述 (Problem):**

1.  **几何畸变 (Geometric Distortion):**
    原代码在计算 `hFOV`（以及随后的 `h_len`）时，错误地使用了基于长宽比的线性缩放：`self.hFOV = (float(self._height) / self._width) * FOV`。
    在透视投影 (Perspective Projection) 中，FOV 与图像尺寸的关系是非线性的（正切函数关系）。这种线性近似会导致当输入图像长宽比不是 1:1 时，输出图像在垂直方向上出现挤压或拉伸（像素非正方形）。

2.  **边缘伪影 (Edge Artifacts):**
    `cv2.remap` 中使用了 `cv2.BORDER_WRAP` 模式。这对于全景图是正确的，但对于透视图像（Perspective Image），会导致边缘处错误地卷绕并采样图像另一侧的像素，产生杂色伪影。

**验证证据 (Evidence):**

以 1024x512 (2:1 长宽比) 的图像为例，设定水平 FOV 为 90°：
* **旧版逻辑:** 计算出 `h_len` ≈ 0.414 (对应垂直 FOV ≈ 45°)。这是错误的，导致像素被压扁。
* **修复后:** 计算出 `h_len` = 0.5 (对应垂直 FOV ≈ 53.1°)。这符合物理光学的正切投影规律，保证了像素是正方形 (Square Pixels)。

**修复内容 (Fix):**

1.  重写了 `__init__` 方法：严格遵循透视投影几何，使用 `np.tan` 根据输入 FOV 和长宽比计算正确的 `w_len` 和 `h_len`。
2.  向后兼容：反向计算并补充了 `wFOV` 和 `hFOV` 属性，防止破坏现有代码的兼容性。
3.  画质修复：将 `cv2.remap` 的边界模式改为 `cv2.BORDER_CONSTANT` (填充黑色)，消除了边缘伪影。